### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -2,7 +2,7 @@
 
 require('./index.styl')
 
-//var Guid = require('node-uuid')
+//var uuid = require('uuid')
 var sorty = require('sorty')
 var React = require('react')
 var ReactDOM = require('react-dom')
@@ -26,7 +26,7 @@ var gen = (function(){
         for (var i = 0; i < len; i++){
             arr.push({
                 id       : i + 1,
-                // id: Guid.create(),
+                // id: uuid.v4(),
                 grade      : Math.round(Math.random() * 10),
                 email    : faker.internet.email(),
                 firstName: faker.name.firstName(),

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "es6-promise": "^3.0.2",
     "has-touch": "^1.0.1",
     "hasown": "^1.0.1",
-    "node-uuid": "^1.4.3",
     "normalize.css": "^3.0.3",
     "object-assign": "^4.0.1",
     "react": "^0.14.0",
@@ -83,6 +82,7 @@
     "region": "^2.1.2",
     "region-align": "^2.1.2",
     "ustring": "^1.4.1",
+    "uuid": "^3.0.0",
     "whatwg-fetch": "^0.10.0"
   },
   "peerDependencies": {

--- a/server/gen.js
+++ b/server/gen.js
@@ -1,5 +1,5 @@
 var faker = require('faker')
-var Guid = require('node-uuid')
+var Guid = require('uuid')
 
 module.exports = (function(){
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.